### PR TITLE
Print output to PDF

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -324,3 +324,19 @@ pre code, pre tt {
   color:#999;
   background-color:#EAF2F5
 }
+
+@media print {
+    #input {
+        display: none;
+    }
+
+    #output {
+        display: block;
+        position: static;
+        left: 0%;
+        right: 0%;
+        top: 0%;
+        width: 100%;
+        height: 100%;
+    }
+}


### PR DESCRIPTION
The following style change allows you to use chrome's print function to print the output or to generate a PDF.

Example generated PDF: http://ianduffy.ie/HelloWorld.pdf
