### PR TITLE
added support for watch mode (-w)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You'll need Google Chrome of course, plus you'll need a python interpreter on yo
 
 You can install from [npm](http://npmjs.org), the Node.js package manager, with <b><code>npm install -g morkdown</code></b> (you may need to `sudo` that depending on your setup). Once installed you can simply run the **`morkdown <path to file.md>`** command and you're away!
 
+If you want to use an editor of your choice, launch morkdown with a *watch flag*, e.g. **`morkdown -w <path to file.md>`** and morkdown will re-render the output in the browser when the file is saved locally.
+
 ## Contributors
 
 **morkdown** is brought to you by the following hackers:

--- a/bin/morkdown.js
+++ b/bin/morkdown.js
@@ -16,7 +16,8 @@ var me     = require('..')
       } catch (e) {}
       return argv
     }())
-  , file   = argv._[0]
+  , watching = argv.w
+  , file   = watching ? argv.w : argv._[0]
   , port   = 2000 + Math.round(Math.random() * 5000)
   , theme  = argv.theme
 
@@ -40,7 +41,7 @@ if (!file) {
   process.exit(-1)
 }
 
-me(file, theme).listen(port)
+me(file, theme, watching).listen(port)
 
 if (os.platform() == 'darwin') {
   if (fs.existsSync('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome')) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,7 @@ var path       = require('path')
   , after      = require('after')
   , bl         = require('bl')
   , ent        = require('ent')
+  , shoe       = require('shoe')
 
   , staticPath = path.join(__dirname, '../static')
 
@@ -18,8 +19,8 @@ function writeHead (res, contentType) {
 }
 
 // constructor
-function Morkdown (file, theme) {
-  if (!(this instanceof Morkdown)) return new Morkdown(file, theme)
+function Morkdown (file, theme, watching) {
+  if (!(this instanceof Morkdown)) return new Morkdown(file, theme, watching)
 
   // file we're editing
   this.file  = file
@@ -33,6 +34,11 @@ function Morkdown (file, theme) {
     , passthrough : false
   })
 
+  // hide input and expand output if we are watching changes to file
+  this.watching = watching
+  this.inputStyle = this.watching ? 'style="display: none;"' : ''
+  this.outputStyle = this.watching ? 'style="left: 0%"' : ''
+
   this.server = http.createServer(function (req, res) {
     // first try to handle it locally, then handler() will defer to st if needed
     this.handler(req, res)
@@ -41,7 +47,30 @@ function Morkdown (file, theme) {
 
 // exportable
 Morkdown.prototype.listen = function () {
+  var sock
+
   this.server.listen.apply(this.server, arguments)
+
+  if (!this.watching)
+    return
+
+  sock = shoe(function (stream) {
+    var opts = { persistent: true, interval: 100 }
+    fs.watchFile(this.file, opts, function () {
+      fs.readFile(this.file, function (err, data) {
+        brucedown(data, function (err, content) {
+          stream.write(JSON.stringify({ content: content }))
+        })
+      })
+    }.bind(this))
+
+    stream.on('end', function () {
+      fs.unwatchFile(this.file)
+    }.bind(this))
+
+  }.bind(this))
+
+  sock.install(this.server, '/output')
 }
 
 // handle /bundle.js requests
@@ -73,6 +102,8 @@ Morkdown.prototype.handle_index_html = function (req, res) {
           .replace('{output}', output)
           .replace('{input}', input)
           .replace('{file}', this.file)
+          .replace('{input-style}', this.inputStyle)
+          .replace('{output-style}', this.outputStyle)
 
         writeHead(res, 'text/html')
         res.end(index)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
         , "codemirror"    : "~3.18.0"
         , "optimist"      : "~0.6.0"
         , "bl"            : "~0.5.0"
+        , "shoe"          : "~0.0.15"
+        , "through"       : "~2.3.4"
       }
   , "bin"          : {
         "morkdown"        : "./bin/morkdown.js"

--- a/static/index.html
+++ b/static/index.html
@@ -27,7 +27,7 @@
     <script src="/bundle.js"></script>
   </head>
   <body data-theme="{theme}">
-    <div id="input"><textarea>{input}</textarea></div>
-    <div id="output"><div>{output}</div></div>
+    <div id="input" {input-style}><textarea>{input}</textarea></div>
+    <div id="output" {output-style}><div>{output}</div></div>
   </body>
 </html>


### PR DESCRIPTION
```
morkdown -w README.md
```

Will only display the rendered output in the client and changes are pushed via shoe() to the client when the file has been changed.

Not sure if you want it or not. I find it usable since I want to use emacs for everything :)
