### PR TITLE
smoother realtime update of rendered markdown display

### DIFF
--- a/browser/index.js
+++ b/browser/index.js
@@ -4,6 +4,7 @@ var ready             = require('domready')
   , concat            = require('concat-stream')
   , shoe              = require('shoe')
   , through           = require('through')
+  , become            = require('become')
 
   , $codeMirror
   , $output
@@ -24,7 +25,7 @@ var handleResponse = function (res) {
     return alert(res.error)
 
   if (res.content)
-    $output.innerHTML = res.content
+    become($output, res.content, {inner: true})
   else
     alert('no content returned from server')
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         , "bl"            : "~0.5.0"
         , "shoe"          : "~0.0.15"
         , "through"       : "~2.3.4"
+        , "become"        : "~1.1.0"
       }
   , "bin"          : {
         "morkdown"        : "./bin/morkdown.js"


### PR DESCRIPTION
I was using morkdown to edit the mmckegg/become readme, but every time I typed, the rendered markdown would jump around as images reloaded. I suddenly realised that [become](http://github.com/mmckegg/become) could be exactly what this project needs.

"Become" works like `element.innerHTML` except that it only updates elements that have actually changed. That way the images won't have to continuously reload and the scroll position will remain constant.
