### PR TITLE
Allow dot-files in static file server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -31,6 +31,7 @@ function Morkdown (file, theme, watching) {
       path  : staticPath
     , url   : '/'
     , cache : false
+    , dot   : true
     , passthrough : false
   })
 


### PR DESCRIPTION
This is necessary when using nvm, as it will install things into
`$HOME/.nvm/$version/lib/node_modules`. This shouldn't create any
sort of risk, as the directory being served is owned by morkdown and
not the user.
