### PR TITLE
adding optional --port rgument

### DIFF
--- a/bin/morkdown.js
+++ b/bin/morkdown.js
@@ -18,7 +18,7 @@ var me     = require('..')
     }())
   , watching = argv.w
   , file   = watching ? argv.w : argv._[0]
-  , port   = 2000 + Math.round(Math.random() * 5000)
+  , port   = argv.port || 2000 + Math.round(Math.random() * 5000)
   , theme  = argv.theme
 
   , bin    = 'google-chrome'


### PR DESCRIPTION
The `port` argument will make it easier to let others collaborate on my blog post.
If this use case is not needed, feel free to ignore this PR and I'll use my fork.
