### PR TITLE
add new brew cask Chrome path

### DIFF
--- a/bin/morkdown.js
+++ b/bin/morkdown.js
@@ -26,6 +26,7 @@ var me     = require('..')
         '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
       , '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary'
       , '/opt/homebrew-cask/Caskroom/google-chrome/stable-channel/Google Chrome.app/Contents/MacOS/Google Chrome'
+      , '/opt/homebrew-cask/Caskroom/google-chrome/latest/Google Chrome.app/Contents/MacOS/Google Chrome'
     ]
   , linuxBin = [
         '/usr/bin/google-chrome'


### PR DESCRIPTION
I've only recently began to use Homebrew Cask to install apps on OS X and it appears that the path for the Google Chrome installation has changed from `/opt/homebrew-cask/Caskroom/google-chrome/stable-channel/` to `/opt/homebrew-cask/Caskroom/google-chrome/latest/`. This caused my newly installed `morkdown` to throw a `new Error('Chrome or Canary were not found')`.

I'm not sure if somebody somewhere might still have the old path so I kept it in there Justin Case. I can remove it if you think it best.
