### PR TITLE
add '/usr/bin/chromium' as a linux binary path

### DIFF
--- a/bin/morkdown.js
+++ b/bin/morkdown.js
@@ -31,6 +31,7 @@ var me     = require('..')
   , linuxBin = [
         '/usr/bin/google-chrome'
       , '/usr/bin/chromium-browser'
+      , '/usr/bin/chromium'
     ]
   , args   = [
         '--app=http://localhost:' + port


### PR DESCRIPTION
The ArchLinux package for Chrome installs the binary at /usr/bin/chromium
